### PR TITLE
Exchanges logging and database updates

### DIFF
--- a/exchanges.test.json
+++ b/exchanges.test.json
@@ -1,44 +1,34 @@
 {
   "exchanges": [
     {
-      "account": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-      "amount": "",
-      "tokens": 123,
-      "usdTotal": 12,
-      "createdAt": "December 17, 1995 03:24:00",
-      "xmrAddress": "4AtpuJrusY7QLDdjjcXTuUQNjw3taZNcWDEY3vfRVKeGAKtuWqt9UwjVk9DXxNUwQxDNTSDJYKLXw9NpDA4Z8gasCu2pvPX"
+      "sender": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+      "recipient": "5DiNxgrprTPRu8iq4LhN8oaCSN17jzSfud1MYdjae1wkieQv",
+      "senderMemo": "Memo test",
+      "amount": 100,
+      "fees": 0,
+      "date": "2020-05-12T12:57:48.000Z",
+      "blockHeight": 1845,
+      "price": 0.003
     },
     {
-      "account": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-      "amount": "",
-      "tokens": 123,
-      "usdTotal": 12,
-      "createdAt": "December 17, 1995 03:24:00",
-      "xmrAddress": "4AtpuJrusY7QLDdjjcXTuUQNjw3taZNcWDEY3vfRVKeGAKtuWqt9UwjVk9DXxNUwQxDNTSDJYKLXw9NpDA4Z8gasCu2pvPX"
+      "sender": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+      "recipient": "5DiNxgrprTPRu8iq4LhN8oaCSN17jzSfud1MYdjae1wkieQv",
+      "senderMemo": "Memo test",
+      "amount": 100,
+      "fees": 0,
+      "date": "2020-05-12T12:59:00.000Z",
+      "blockHeight": 1857,
+      "price": 0.003
     },
     {
-      "account": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-      "amount": "",
-      "tokens": 123,
-      "usdTotal": 12,
-      "createdAt": "December 17, 1995 03:24:00",
-      "xmrAddress": "4AtpuJrusY7QLDdjjcXTuUQNjw3taZNcWDEY3vfRVKeGAKtuWqt9UwjVk9DXxNUwQxDNTSDJYKLXw9NpDA4Z8gasCu2pvPX"
-    },
-    {
-      "account": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-      "amount": "",
-      "tokens": 123,
-      "usdTotal": 12,
-      "createdAt": "December 17, 1995 03:24:00",
-      "xmrAddress": "4AtpuJrusY7QLDdjjcXTuUQNjw3taZNcWDEY3vfRVKeGAKtuWqt9UwjVk9DXxNUwQxDNTSDJYKLXw9NpDA4Z8gasCu2pvPX"
-    },
-    {
-      "account": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-      "amount": "",
-      "tokens": 123,
-      "usdTotal": 12,
-      "createdAt": "December 17, 1995 03:24:00",
-      "xmrAddress": "4AtpuJrusY7QLDdjjcXTuUQNjw3taZNcWDEY3vfRVKeGAKtuWqt9UwjVk9DXxNUwQxDNTSDJYKLXw9NpDA4Z8gasCu2pvPX"
+      "sender": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+      "recipient": "5DiNxgrprTPRu8iq4LhN8oaCSN17jzSfud1MYdjae1wkieQv",
+      "senderMemo": "Memo test",
+      "amount": 999,
+      "fees": 0,
+      "date": "2020-05-12T13:04:06.000Z",
+      "blockHeight": 1908,
+      "price": 0.003
     }
   ],
   "replenishAmount": 100,

--- a/exchanges.test.json
+++ b/exchanges.test.json
@@ -29,6 +29,16 @@
       "date": "2020-05-12T13:04:06.000Z",
       "blockHeight": 1908,
       "price": 0.003
+    },
+    {
+      "sender": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+      "recipient": "5DiNxgrprTPRu8iq4LhN8oaCSN17jzSfud1MYdjae1wkieQv",
+      "senderMemo": "Memo test",
+      "amount": 100,
+      "fees": 0,
+      "date": "2020-05-12T13:17:48.000Z",
+      "blockHeight": 2045,
+      "price": 0.003
     }
   ],
   "replenishAmount": 100,

--- a/exchanges.test.json
+++ b/exchanges.test.json
@@ -3,7 +3,7 @@
     {
       "sender": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
       "recipient": "5DiNxgrprTPRu8iq4LhN8oaCSN17jzSfud1MYdjae1wkieQv",
-      "senderMemo": "Memo test",
+      "xmrAddress": "8171ac877cd006932f317470a51f6ae0c71762bc7871c9042bdf92bd7070cf00",
       "amount": 100,
       "fees": 0,
       "date": "2020-05-12T12:57:48.000Z",
@@ -13,7 +13,7 @@
     {
       "sender": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
       "recipient": "5DiNxgrprTPRu8iq4LhN8oaCSN17jzSfud1MYdjae1wkieQv",
-      "senderMemo": "Memo test",
+      "xmrAddress": "8171ac877cd006932f317470a51f6ae0c71762bc7871c9042bdf92bd7070cf00",
       "amount": 100,
       "fees": 0,
       "date": "2020-05-12T12:59:00.000Z",
@@ -23,7 +23,7 @@
     {
       "sender": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
       "recipient": "5DiNxgrprTPRu8iq4LhN8oaCSN17jzSfud1MYdjae1wkieQv",
-      "senderMemo": "Memo test",
+      "xmrAddress": "8171ac877cd006932f317470a51f6ae0c71762bc7871c9042bdf92bd7070cf00",
       "amount": 999,
       "fees": 0,
       "date": "2020-05-12T13:04:06.000Z",
@@ -33,7 +33,7 @@
     {
       "sender": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
       "recipient": "5DiNxgrprTPRu8iq4LhN8oaCSN17jzSfud1MYdjae1wkieQv",
-      "senderMemo": "Memo test",
+      "xmrAddress": "8171ac877cd006932f317470a51f6ae0c71762bc7871c9042bdf92bd7070cf00",
       "amount": 100,
       "fees": 0,
       "date": "2020-05-12T13:17:48.000Z",

--- a/package.json
+++ b/package.json
@@ -16,11 +16,13 @@
     "@polkadot/util": "^1.7.0-beta.5",
     "@polkadot/util-crypto": "^1.7.0-beta.5",
     "@types/bn.js": "^4.11.5",
+    "@types/locks": "^0.2.1",
     "bignumber.js": "^9.0.0",
     "bn.js": "^4.11.8",
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
+    "locks": "^0.2.2",
     "lowdb": "^1.0.0"
   },
   "devDependencies": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,9 +1,12 @@
 import express from "express";
 import cors from "cors";
 import { getStatus } from "./get-status";
+import startTransfersMonitor from './transfers';
 
 const app = express();
 const port = process.env.PORT || 8081;
+
+startTransfersMonitor();
 
 app.use(cors());
 app.get("/", async (req, res) => {

--- a/src/db.ts
+++ b/src/db.ts
@@ -15,6 +15,7 @@ type Exchange = {
 type Schema = {
     exchanges: Exchange[];
     sizeDollarPool: number,
+    poolLastUpdated: number, // Block number
     replenishAmount: number,
     tokensBurned: number
 };

--- a/src/db.ts
+++ b/src/db.ts
@@ -9,7 +9,8 @@ type Exchange = {
     fees: number,
     date: Date,
     blockHeight: number,
-    price: number
+    price: number,
+    amountUSD: number
 };
 
 type BlockProcessingError = {

--- a/src/db.ts
+++ b/src/db.ts
@@ -12,15 +12,21 @@ type Exchange = {
     price: number
 };
 
+type BlockProcessingError = {
+    blockNumber: number;
+    reason?: string;
+}
+
 type Schema = {
     exchanges: Exchange[];
     sizeDollarPool: number,
     lastBlockProcessed: number,
     replenishAmount: number,
-    tokensBurned: number
+    tokensBurned: number,
+    errors: BlockProcessingError[]
 };
 
 const adapter = new FileAsync<Schema>("exchanges.test.json");
 const db = low(adapter);
 
-export { db, Exchange };
+export { db, Exchange, BlockProcessingError };

--- a/src/db.ts
+++ b/src/db.ts
@@ -15,7 +15,7 @@ type Exchange = {
 type Schema = {
     exchanges: Exchange[];
     sizeDollarPool: number,
-    poolLastUpdated: number, // Block number
+    lastBlockProcessed: number,
     replenishAmount: number,
     tokensBurned: number
 };

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,7 +1,25 @@
 import low from "lowdb";
 import FileAsync from "lowdb/adapters/FileAsync";
 
-const adapter = new FileAsync("exchanges.test.json");
+type Exchange = {
+    sender: string,
+    recipient: string,
+    senderMemo: string,
+    amount: number,
+    fees: number,
+    date: Date,
+    blockHeight: number,
+    price: number
+};
+
+type Schema = {
+    exchanges: Exchange[];
+    sizeDollarPool: number,
+    replenishAmount: number,
+    tokensBurned: number
+};
+
+const adapter = new FileAsync<Schema>("exchanges.test.json");
 const db = low(adapter);
 
-export { db };
+export { db, Exchange };

--- a/src/db.ts
+++ b/src/db.ts
@@ -4,7 +4,7 @@ import FileAsync from "lowdb/adapters/FileAsync";
 type Exchange = {
     sender: string,
     recipient: string,
-    senderMemo: string,
+    xmrAddress: string,
     amount: number,
     fees: number,
     date: Date,

--- a/src/joyApi.ts
+++ b/src/joyApi.ts
@@ -207,9 +207,9 @@ export class JoyApi {
     };
   }
 
-  async price(blockHash?: Hash) {
+  async price(blockHash?: Hash, dollarPoolSize?: number) {
     let supply = new BigNumber((await this.IssuanceMinusBurned(blockHash)).toNumber());
-    let size = new BigNumber((await this.dollarPool()).size);
+    let size = new BigNumber(dollarPoolSize !== undefined ? dollarPoolSize : (await this.dollarPool()).size);
 
     return size.div(supply).toFixed(3);
   }

--- a/src/transfers.ts
+++ b/src/transfers.ts
@@ -26,7 +26,7 @@ async function main() {
     const blockHash = head.hash;
     const events = await api.query.system.events.at(blockHash) as Vec<EventRecord>;
     const previousBlockNumber = blockNumber.toNumber() - 1;
-    let currentDollarPool = 0, sumDollarsInBlock = 0;
+    let currentDollarPool = 0, currentTokensBurned = 0, sumDollarsInBlock = 0, sumTokensInBlock = 0;
 
     // Since event handler is an async function, we await until previous block
     // is processed (which it probably is at this point) just to make sure we get
@@ -34,9 +34,10 @@ async function main() {
     await (new Promise((resolve) =>
       setTimeout(
         async () => {
-          const { sizeDollarPool, poolLastUpdated } = (await db).valueOf();
-          if (!INITIALIZED || poolLastUpdated === previousBlockNumber) {
+          const { sizeDollarPool, tokensBurned, lastBlockProcessed } = (await db).valueOf();
+          if (!INITIALIZED || lastBlockProcessed === previousBlockNumber) {
             INITIALIZED = true;
+            currentTokensBurned = tokensBurned;
             currentDollarPool = sizeDollarPool;
             resolve();
           }
@@ -44,6 +45,9 @@ async function main() {
         100
       )
     ));
+
+    // To calcultate the price we use parent hash (so all the transactions that happend in this block have no effect on it)
+    const price = await joy.price(head.parentHash, currentDollarPool);
 
     // Processing all events in the finalized block
     console.log(`\nProcessing block #${ blockNumber }...`);
@@ -57,8 +61,6 @@ async function main() {
           const feesJOY = event.data[3] as Balance;
           const timestamp = await api.query.timestamp.now.at(blockHash) as Moment;
           const memo = await api.query.memo.memo.at(blockHash, sender) as Text;
-          // To calcultate the price we use parent hash (so all the transactions that happend in this block have no effect on it)
-          const price = await joy.price(head.parentHash, currentDollarPool);
 
           const exchange: Exchange = {
             sender: sender.toString(),
@@ -79,6 +81,7 @@ async function main() {
           console.log('Exchange happened!', exchange);
 
           sumDollarsInBlock += exchange.amount * exchange.price;
+          sumTokensInBlock  += exchange.amount;
         }
       }
     }
@@ -86,12 +89,15 @@ async function main() {
     // We update the dollar pool after processing all transactions in this block
     (await db)
       .set('sizeDollarPool', currentDollarPool - sumDollarsInBlock)
-      .set('poolLastUpdated', blockNumber.toNumber())
+      .set('tokensBurned', currentTokensBurned + sumTokensInBlock)
+      .set('lastBlockProcessed', blockNumber.toNumber())
       .write();
 
-    console.log('Dollar pool before', currentDollarPool);
+    console.log('Tokens in block:', sumTokensInBlock);
+    console.log('Token price:', price);
     console.log('Dollars in block:', sumDollarsInBlock);
     console.log('Dollar pool after:', currentDollarPool - sumDollarsInBlock);
+    console.log('Tokens burned after:', currentTokensBurned + sumTokensInBlock);
   });
 }
 

--- a/src/transfers.ts
+++ b/src/transfers.ts
@@ -161,4 +161,4 @@ async function main() {
   });
 }
 
-main().catch(console.error);
+export default main;

--- a/src/transfers.ts
+++ b/src/transfers.ts
@@ -10,6 +10,7 @@ config();
 const provider = process.env.PROVIDER || "ws://127.0.0.1:9944";
 
 const joy = new JoyApi(provider);
+let INITIALIZED = false;
 
 // Known account we want to use (available on dev chain, with funds)
 
@@ -24,18 +25,40 @@ async function main() {
     const blockNumber = head.number;
     const blockHash = head.hash;
     const events = await api.query.system.events.at(blockHash) as Vec<EventRecord>;
+    const previousBlockNumber = blockNumber.toNumber() - 1;
+    let currentDollarPool = 0, sumDollarsInBlock = 0;
 
+    // Since event handler is an async function, we await until previous block
+    // is processed (which it probably is at this point) just to make sure we get
+    // valid currentDollarPool to calculate the price
+    await (new Promise((resolve) =>
+      setTimeout(
+        async () => {
+          const { sizeDollarPool, poolLastUpdated } = (await db).valueOf();
+          if (!INITIALIZED || poolLastUpdated === previousBlockNumber) {
+            INITIALIZED = true;
+            currentDollarPool = sizeDollarPool;
+            resolve();
+          }
+        },
+        100
+      )
+    ));
+
+    // Processing all events in the finalized block
+    console.log(`\nProcessing block #${ blockNumber }...`);
     for (let { event } of events) {
       if (event.section === 'balances' && event.method === 'Transfer') {
-        const sender = event.data[0] as AccountId;
         const recipient = event.data[1] as AccountId;
         if (recipient.toString() === process.env.JSGENESIS_ADDRESS) {
+          // For all events of "Transfer" type with matching recipient...
+          const sender = event.data[0] as AccountId;
           const amountJOY = event.data[2] as Balance;
           const feesJOY = event.data[3] as Balance;
           const timestamp = await api.query.timestamp.now.at(blockHash) as Moment;
           const memo = await api.query.memo.memo.at(blockHash, sender) as Text;
-          // For price we use parent hash (so it's a price before the transaction, not after)
-          const price = await joy.price(head.parentHash);
+          // To calcultate the price we use parent hash (so all the transactions that happend in this block have no effect on it)
+          const price = await joy.price(head.parentHash, currentDollarPool);
 
           const exchange: Exchange = {
             sender: sender.toString(),
@@ -52,9 +75,23 @@ async function main() {
             .get('exchanges', [])
             .push(exchange)
             .write();
+
+          console.log('Exchange happened!', exchange);
+
+          sumDollarsInBlock += exchange.amount * exchange.price;
         }
       }
     }
+
+    // We update the dollar pool after processing all transactions in this block
+    (await db)
+      .set('sizeDollarPool', currentDollarPool - sumDollarsInBlock)
+      .set('poolLastUpdated', blockNumber.toNumber())
+      .write();
+
+    console.log('Dollar pool before', currentDollarPool);
+    console.log('Dollars in block:', sumDollarsInBlock);
+    console.log('Dollar pool after:', currentDollarPool - sumDollarsInBlock);
   });
 }
 

--- a/src/transfers.ts
+++ b/src/transfers.ts
@@ -3,101 +3,161 @@ import { JoyApi } from "./joyApi";
 import { config } from "dotenv";
 import { Text } from "@polkadot/types";
 import { Vec } from '@polkadot/types/codec';
-import { EventRecord, Moment, AccountId, Balance } from '@polkadot/types/interfaces';
-import { db, Exchange } from './db';
+import { EventRecord, Moment, AccountId, Balance, Header } from '@polkadot/types/interfaces';
+import { db, Exchange, BlockProcessingError } from './db';
+import { ApiPromise } from "@polkadot/api";
+import locks from "locks";
 config();
+
+const processingLock = locks.createMutex();
 
 const provider = process.env.PROVIDER || "ws://127.0.0.1:9944";
 
 const joy = new JoyApi(provider);
-let INITIALIZED = false;
+
+const BLOCK_PROCESSING_TIMEOUT = 10000;
+const FIRST_BLOCK_TO_PROCESS = 1;
 
 // Known account we want to use (available on dev chain, with funds)
 
 // Listen to all tx to Jsgenesis address
 // Add them to exchanges. Calculate the Dollar Value, and log all the other info. Set completed to false.
 
+// If for some reason we cannot process given block and all the attempts to do so fail,
+// we log the fault block number, update the database and exit the process to avoid inconsistencies. 
+async function critialExit(faultBlockNumber: number, reason?: string) {
+  await (await db)
+    .defaults({ errors: [] as BlockProcessingError[] })
+    .get('errors')
+    .push({ blockNumber: faultBlockNumber, reason })
+    .write();
+
+  await (await db)
+    .set('lastBlockProcessed', faultBlockNumber)
+    .write();
+
+  console.log('Critical error, extiting...');
+  console.log('Faulty block:', faultBlockNumber);
+  console.log('Reason:', reason);
+  process.exit();
+}
+
+async function processBlock(api: ApiPromise, head: Header) {
+  try {
+    await new Promise(async (resolve, reject) => {
+      // Set block processing timeout to avoid infinite lock
+      const processingTimeout = setTimeout(
+        () => reject('Block processing timeout'),
+        BLOCK_PROCESSING_TIMEOUT
+      );
+      // Set lock to avoid processing multiple blocks at the same time
+      processingLock.lock(async () => {
+        const blockNumber = head.number;
+        const { lastBlockProcessed = FIRST_BLOCK_TO_PROCESS - 1 } = (await db).valueOf();
+
+        // Ignore blocks that are (or should be) already processed
+        if (blockNumber.toNumber() <= lastBlockProcessed) {
+          processingLock.unlock();
+          clearTimeout(processingTimeout);
+          return;
+        }
+
+        console.log(`\nProcessing block #${ blockNumber }...`);
+
+        const blockHash = head.hash;
+        const events = await api.query.system.events.at(blockHash) as Vec<EventRecord>;
+        const { sizeDollarPool: currentDollarPool = 0, tokensBurned: currentTokensBurned = 0 } = (await db).valueOf();
+        let sumDollarsInBlock = 0, sumTokensInBlock = 0;
+
+        // To calcultate the price we use parent hash (so all the transactions that happend in this block have no effect on it)
+        const price = await joy.price(head.parentHash, currentDollarPool);
+
+        // Processing all events in the finalized block
+        for (let { event } of events) {
+          if (event.section === 'balances' && event.method === 'Transfer') {
+            const recipient = event.data[1] as AccountId;
+            if (recipient.toString() === process.env.JSGENESIS_ADDRESS) {
+              // For all events of "Transfer" type with matching recipient...
+              const sender = event.data[0] as AccountId;
+              const amountJOY = event.data[2] as Balance;
+              const feesJOY = event.data[3] as Balance;
+              const timestamp = await api.query.timestamp.now.at(blockHash) as Moment;
+              const memo = await api.query.memo.memo.at(blockHash, sender) as Text;
+
+              const exchange: Exchange = {
+                sender: sender.toString(),
+                recipient: recipient.toString(),
+                senderMemo: memo.toString(),
+                amount: amountJOY.toNumber(),
+                fees: feesJOY.toNumber(),
+                date: new Date(timestamp.toNumber()),
+                blockHeight: blockNumber.toNumber(),
+                price: parseFloat(price),
+              };
+
+              await (await db)
+                .defaults({ exchanges: [] as Exchange[] })
+                .get('exchanges', [])
+                .push(exchange)
+                .write();
+
+              console.log('Exchange happened!', exchange);
+
+              sumDollarsInBlock += exchange.amount * exchange.price;
+              sumTokensInBlock  += exchange.amount;
+            }
+          }
+        }
+
+        // We update the dollar pool after processing all transactions in this block
+        await (await db)
+          .set('sizeDollarPool', currentDollarPool - sumDollarsInBlock)
+          .set('tokensBurned', currentTokensBurned + sumTokensInBlock)
+          .set('lastBlockProcessed', blockNumber.toNumber())
+          .write();
+
+        console.log('Tokens in block:', sumTokensInBlock);
+        console.log('Token price:', price);
+        console.log('Dollars in block:', sumDollarsInBlock);
+        console.log('Dollar pool after:', currentDollarPool - sumDollarsInBlock);
+        console.log('Tokens burned after:', currentTokensBurned + sumTokensInBlock);
+
+        processingLock.unlock();
+        clearTimeout(processingTimeout);
+        resolve();
+      });
+    });
+  } catch (e) {
+    await critialExit(head.number.toNumber(), JSON.stringify(e));
+  }
+}
+
+async function processPastBlocks(api: ApiPromise, from: number, to: number) {
+  for (let blockNumber = from; blockNumber <= to; ++blockNumber) {
+    const hash = await api.rpc.chain.getBlockHash(blockNumber);
+    const singedBlock = await api.rpc.chain.getBlock(hash);
+    const header = singedBlock.block.header;
+    try {
+      await processBlock(api, header);
+    } catch (e) {
+      critialExit(header.number.toNumber(), JSON.stringify(e));
+    }
+  }
+}
+
 async function main() {
   // Create an await for the API
   const { api } = await joy.init;
 
   api.rpc.chain.subscribeFinalizedHeads(async head => {
-    const blockNumber = head.number;
-    const blockHash = head.hash;
-    const events = await api.query.system.events.at(blockHash) as Vec<EventRecord>;
-    const previousBlockNumber = blockNumber.toNumber() - 1;
-    let currentDollarPool = 0, currentTokensBurned = 0, sumDollarsInBlock = 0, sumTokensInBlock = 0;
-
-    // Since event handler is an async function, we await until previous block
-    // is processed (which it probably is at this point) just to make sure we get
-    // valid currentDollarPool to calculate the price
-    await (new Promise((resolve) =>
-      setTimeout(
-        async () => {
-          const { sizeDollarPool, tokensBurned, lastBlockProcessed } = (await db).valueOf();
-          if (!INITIALIZED || lastBlockProcessed === previousBlockNumber) {
-            INITIALIZED = true;
-            currentTokensBurned = tokensBurned;
-            currentDollarPool = sizeDollarPool;
-            resolve();
-          }
-        },
-        100
-      )
-    ));
-
-    // To calcultate the price we use parent hash (so all the transactions that happend in this block have no effect on it)
-    const price = await joy.price(head.parentHash, currentDollarPool);
-
-    // Processing all events in the finalized block
-    console.log(`\nProcessing block #${ blockNumber }...`);
-    for (let { event } of events) {
-      if (event.section === 'balances' && event.method === 'Transfer') {
-        const recipient = event.data[1] as AccountId;
-        if (recipient.toString() === process.env.JSGENESIS_ADDRESS) {
-          // For all events of "Transfer" type with matching recipient...
-          const sender = event.data[0] as AccountId;
-          const amountJOY = event.data[2] as Balance;
-          const feesJOY = event.data[3] as Balance;
-          const timestamp = await api.query.timestamp.now.at(blockHash) as Moment;
-          const memo = await api.query.memo.memo.at(blockHash, sender) as Text;
-
-          const exchange: Exchange = {
-            sender: sender.toString(),
-            recipient: recipient.toString(),
-            senderMemo: memo.toString(),
-            amount: amountJOY.toNumber(),
-            fees: feesJOY.toNumber(),
-            date: new Date(timestamp.toNumber()),
-            blockHeight: blockNumber.toNumber(),
-            price: parseFloat(price),
-          };
-
-          (await db)
-            .get('exchanges', [])
-            .push(exchange)
-            .write();
-
-          console.log('Exchange happened!', exchange);
-
-          sumDollarsInBlock += exchange.amount * exchange.price;
-          sumTokensInBlock  += exchange.amount;
-        }
-      }
-    }
-
-    // We update the dollar pool after processing all transactions in this block
-    (await db)
-      .set('sizeDollarPool', currentDollarPool - sumDollarsInBlock)
-      .set('tokensBurned', currentTokensBurned + sumTokensInBlock)
-      .set('lastBlockProcessed', blockNumber.toNumber())
-      .write();
-
-    console.log('Tokens in block:', sumTokensInBlock);
-    console.log('Token price:', price);
-    console.log('Dollars in block:', sumDollarsInBlock);
-    console.log('Dollar pool after:', currentDollarPool - sumDollarsInBlock);
-    console.log('Tokens burned after:', currentTokensBurned + sumTokensInBlock);
+    const { lastBlockProcessed = FIRST_BLOCK_TO_PROCESS - 1 } = (await db).valueOf();
+    const blockNumber = head.number.toNumber();
+    // Ignore already processed blocks
+    if (blockNumber <= lastBlockProcessed) return;
+    // Make sure all previous blocks are processed before processing the new one
+    await processPastBlocks(api, lastBlockProcessed + 1, head.number.toNumber());
+    // Process current block
+    await processBlock(api, head);
   });
 }
 

--- a/src/transfers.ts
+++ b/src/transfers.ts
@@ -87,7 +87,7 @@ async function processBlock(api: ApiPromise, head: Header) {
               const exchange: Exchange = {
                 sender: sender.toString(),
                 recipient: recipient.toString(),
-                senderMemo: memo.toString(),
+                xmrAddress: memo.toString(),
                 amount: amountJOY.toNumber(),
                 fees: feesJOY.toNumber(),
                 date: new Date(timestamp.toNumber()),

--- a/src/transfers.ts
+++ b/src/transfers.ts
@@ -34,7 +34,8 @@ async function main() {
           const feesJOY = event.data[3] as Balance;
           const timestamp = await api.query.timestamp.now.at(blockHash) as Moment;
           const memo = await api.query.memo.memo.at(blockHash, sender) as Text;
-          const price = await joy.price(blockHash);
+          // For price we use parent hash (so it's a price before the transaction, not after)
+          const price = await joy.price(head.parentHash);
 
           const exchange: Exchange = {
             sender: sender.toString(),

--- a/src/transfers.ts
+++ b/src/transfers.ts
@@ -1,6 +1,10 @@
 //import { db } from "./testdb";
 import { JoyApi } from "./joyApi";
 import { config } from "dotenv";
+import { Text } from "@polkadot/types";
+import { Vec } from '@polkadot/types/codec';
+import { EventRecord, Moment, AccountId, Balance } from '@polkadot/types/interfaces';
+import { db, Exchange } from './db';
 config();
 
 const provider = process.env.PROVIDER || "ws://127.0.0.1:9944";
@@ -16,20 +20,40 @@ async function main() {
   // Create an await for the API
   const { api } = await joy.init;
 
-  api.query.system.events((events: any) => {
-    console.log("----- Received " + events.length + " event(s): -----");
-    // loop through the Vec<EventRecord>
-    events.forEach((record: any) => {
-      // extract the phase, event and the event types
-      const { event, phase, topics } = record;
-      const types = event.typeDef;
-      // show what we are busy with
-      console.log(JSON.stringify({ event, phase, topics }));
-      // loop through each of the parameters, displaying the type and data
-      event.data.forEach((data: any, index: any) => {
-        console.log(types[index].type + ";" + data.toString());
-      });
-    });
+  api.rpc.chain.subscribeFinalizedHeads(async head => {
+    const blockNumber = head.number;
+    const blockHash = head.hash;
+    const events = await api.query.system.events.at(blockHash) as Vec<EventRecord>;
+
+    for (let { event } of events) {
+      if (event.section === 'balances' && event.method === 'Transfer') {
+        const sender = event.data[0] as AccountId;
+        const recipient = event.data[1] as AccountId;
+        if (recipient.toString() === process.env.JSGENESIS_ADDRESS) {
+          const amountJOY = event.data[2] as Balance;
+          const feesJOY = event.data[3] as Balance;
+          const timestamp = await api.query.timestamp.now.at(blockHash) as Moment;
+          const memo = await api.query.memo.memo.at(blockHash, sender) as Text;
+          const price = await joy.price(blockHash);
+
+          const exchange: Exchange = {
+            sender: sender.toString(),
+            recipient: recipient.toString(),
+            senderMemo: memo.toString(),
+            amount: amountJOY.toNumber(),
+            fees: feesJOY.toNumber(),
+            date: new Date(timestamp.toNumber()),
+            blockHeight: blockNumber.toNumber(),
+            price: parseFloat(price),
+          };
+
+          (await db)
+            .get('exchanges', [])
+            .push(exchange)
+            .write();
+        }
+      }
+    }
   });
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -248,6 +248,11 @@
   resolved "https://registry.yarnpkg.com/@types/filewriter/-/filewriter-0.0.28.tgz#c054e8af4d9dd75db4e63abc76f885168714d4b3"
   integrity sha1-wFTor02d11205jq8dviFFocU1LM=
 
+"@types/locks@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@types/locks/-/locks-0.2.1.tgz#0f19bb260d67fd70501686381d702a2695f62965"
+  integrity sha512-bYPg6w1CgCUbZwDVp4a483FoZVM8glIfqU2Zx8sl5tJt4Dd9Gz/ya8+3KpCIvedT/ooNqP2/yHqHBjndYNgGbA==
+
 "@types/lodash@*":
   version "4.14.150"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.150.tgz#649fe44684c3f1fcb6164d943c5a61977e8cf0bd"
@@ -1284,6 +1289,11 @@ latest-version@^5.0.0:
   integrity sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==
   dependencies:
     package-json "^6.3.0"
+
+locks@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/locks/-/locks-0.2.2.tgz#259933d1327cbaf0fd3662f8fffde36809d84ced"
+  integrity sha1-JZkz0TJ8uvD9NmL4//3jaAnYTO0=
 
 lodash@4:
   version "4.17.15"


### PR DESCRIPTION
This PR implements adding logs of burning transactions to the databse based on the chain subscription. Each transaction log consists of:
- `sender` (address)
- `recipient` (address)
- `senderMemo` (at the moment of transaction)
- `amount` (of tokens sent)
- `fees`
- `date` (of the transaction)
- `blockHeight` (of the transaction)
- `price` (of one token at the moment of transaction)

It also updates `tokensBurned` and `sizeDollarPool` after each processed block.

Important things to note:
- There is a mechanism which prevents processing block `x` before block `x-1` is processed to prevent the possibility of using outdated `sizeDollarPool` etc. (since blocks are processed asnychronously)
- This check is skipped for the first block beeing processed after the script is run (so it can be run succesfully with outdated or no value in `lastBlockProcessed` field in the database)
- I think we should be only processing finalized blocks, that's why I changed `api.query.system.events` subscription to `api.rpc.chain.subscribeFinalizedHeads`, which also gives us some useful data like block hash, block number, parent hash etc., which we can then use to fetch the data we need using `.at()`