### PR TITLE
Add route for setting exchange status

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3,17 +3,55 @@ import cors from "cors";
 import { getStatus } from "./get-status";
 import startTransfersMonitor from './transfers';
 import { log } from './debug';
+import { setExchangeStatus } from './setExchangeStatus';
 
 const app = express();
 const port = process.env.PORT || 8081;
 
+if(process.env.PASSWORD === undefined) {
+    throw new Error("Missing PASSWORD in .env!");
+}
+
 startTransfersMonitor();
 
 app.use(cors());
+app.use(express.json());
+
 app.get("/", async (req, res) => {
   let status = await getStatus();
   res.setHeader("Content-Type", "application/json");
   res.send(status);
+});
+
+app.post("/status", async (req,res) => {
+    const password = req.header("x-api-key");
+
+    if(process.env.PASSWORD !== password) {
+        res.status(401).send({
+            message: "Wrong authentication credentials!"
+        });
+        return;
+    }
+
+    const { exchangeIndex, exchangeStatus } = req.body;
+
+    if(!exchangeIndex || !exchangeStatus) {
+        res.status(400).send({
+            message: "Missing exchangeIndex or exchangeStatus in request body."
+        });
+        return;
+    }
+
+    const error = await setExchangeStatus(exchangeIndex, exchangeStatus);
+
+    if(error) {
+        res.status(400).send({ message: error });
+        return;
+    }
+
+    res.status(200).send({
+        message: `Succesfully updated the status of exchange ${exchangeIndex}`
+    });
 });
 
 app.listen(port, () => {

--- a/src/setExchangeStatus.ts
+++ b/src/setExchangeStatus.ts
@@ -1,0 +1,37 @@
+import { db, ExchangeStatuses, ExchangeStatus, Schema, Exchange } from './db';
+
+export async function setExchangeStatus(index: number, status: string) {
+  if (!ExchangeStatuses.includes(status as any)) {
+    console.warn("Invalid status! Available statuses are:", ExchangeStatuses);
+    return;
+  }
+
+  const { exchanges = [] } = (await db).valueOf() as Schema;
+  const exchange = exchanges[index];
+
+  if (!exchange) {
+    return "No exchange found at given index!";
+  }
+
+  if (exchange.status === "FINALIZED") {
+    return "Cannot change status of FINALIZED exchange!";
+  }
+
+  // Update exchange status
+  (await db)
+    .defaults({ exchanges: [] as Exchange[] })
+    .get("exchanges")
+    .get(index)
+    .assign({ status })
+    .value();
+  if ((status as ExchangeStatus) === "FINALIZED") {
+    // Update totalUSDPaid
+    (await db)
+      .defaults({ totalUSDPaid: 0 })
+      .update("totalUSDPaid", prev => prev + exchange.amountUSD)
+      .value();
+  }
+  // Save changes
+  (await db).write();
+  return null;
+}


### PR DESCRIPTION
Changes:
- Implement `setExchangeStatus` as a function separate from the commands folder.
- Add `/status` post route to allow the setting of exchange status via api rather than having to manually do it by ssh-ing into the server.