### PR TITLE
Update for Olympia

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "bn.js": "4.12.0"
   },
   "dependencies": {
-    "@joystream/types": "^0.17.2",
+    "@joystream/types": "^0.18.1",
     "@polkadot/api": "5.9.1",
     "@polkadot/keyring": "7.3.1",
     "@polkadot/types": "5.9.1",

--- a/src/db.ts
+++ b/src/db.ts
@@ -8,8 +8,6 @@ export type ExchangeStatus = typeof ExchangeStatuses[number];
 type Exchange = {
   sender: string;
   recipient: string;
-  senderMemo: string;
-  xmrAddress: string;
   amount: number;
   date: Date;
   logTime: Date;

--- a/src/joyApi.ts
+++ b/src/joyApi.ts
@@ -369,14 +369,10 @@ export class JoyApi {
     // and we therefore don't want to try and burn the whole balance but rather try to keep the
     // account balance at the EXISTENTIAL_DEPOSIT amount.
 
-    const EXISTENTIAL_DEPOSIT = 10;
     const freeBalance = burnAddrInfo.data.free.toNumber();
+    const EXISTENTIAL_DEPOSIT = this.api.consts.balances.existentialDeposit.toNumber();
 
-    if(freeBalance > EXISTENTIAL_DEPOSIT) {
-      return burnAddrInfo.data.free.toNumber() - EXISTENTIAL_DEPOSIT;
-    }
-
-    return 0;
+    return Math.max(freeBalance - EXISTENTIAL_DEPOSIT, 0);
   }
 
   async executedBurnsAmount(): Promise<number> {

--- a/src/joyApi.ts
+++ b/src/joyApi.ts
@@ -364,7 +364,19 @@ export class JoyApi {
 
   async burnAddressBalance(): Promise<number> {
     const burnAddrInfo = await this.api.query.system.account(BURN_ADDRESS);
-    return burnAddrInfo.data.free.toNumber(); // Free balance
+
+    // An account needs to constantly have a minimum of EXISTENTIAL_DEPOSIT to be deemed active
+    // and we therefore don't want to try and burn the whole balance but rather try to keep the
+    // account balance at the EXISTENTIAL_DEPOSIT amount.
+
+    const EXISTENTIAL_DEPOSIT = 10;
+    const freeBalance = burnAddrInfo.data.free.toNumber();
+
+    if(freeBalance > EXISTENTIAL_DEPOSIT) {
+      return burnAddrInfo.data.free.toNumber() - EXISTENTIAL_DEPOSIT;
+    }
+
+    return 0;
   }
 
   async executedBurnsAmount(): Promise<number> {

--- a/src/transfers.ts
+++ b/src/transfers.ts
@@ -156,29 +156,11 @@ async function processBlock(api: ApiPromise, block: Block) {
         
         // Handlers
         const handleExchange = async (senderAddress: string, amount: number) => {
-          const memo = await api.query.memo.memo.at(blockHash, senderAddress);
           const amountUSD = price * amount;
-          let match: string = 'No address found'
-          const parseAddress = (address: string) => {
-            const regexps: RegExp[] = [
-              new RegExp('(1|3)[a-km-zA-HJ-NP-Z1-9]{25,34}'),
-              new RegExp('(q|p)[a-z0-9]{41}'),
-              new RegExp('(4|8)[1-9A-HJ-NP-Za-km-z]{94}')
-            ]
-            for (let regexp of regexps) {
-              let matches = address.match(regexp)
-              if (matches!==null) {
-                match = matches[0]
-              }
-            }
-            return match
-          }
 
           const exchange: Exchange = {
             sender: senderAddress,
             recipient: BURN_ADDRESS,
-            senderMemo: memo.toString(),
-            xmrAddress: parseAddress(memo.toString()),
             amount: amount,
             date: new Date(blockTimestamp.toNumber()),
             blockHeight: blockNumber,

--- a/src/transfers.ts
+++ b/src/transfers.ts
@@ -200,7 +200,9 @@ async function processBlock(api: ApiPromise, block: Block) {
 
         // Processing extrinsics in the finalized block
         for (const [index, extrinsic] of Object.entries(extrinsics.toArray())) {
-          if (!(extrinsic.method.section === 'balances' && extrinsic.method.method === 'transfer')) {
+          const TRANSFER_METHODS = ['transfer', 'transferKeepAlive'];
+
+          if (!(extrinsic.method.section === 'balances' && TRANSFER_METHODS.includes(extrinsic.method.method))) {
             continue;
           }
           

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,10 +21,10 @@
   dependencies:
     "@cspotcode/source-map-consumer" "0.8.0"
 
-"@joystream/types@^0.17.2":
-  version "0.17.2"
-  resolved "https://registry.yarnpkg.com/@joystream/types/-/types-0.17.2.tgz#e0a2adabd66c5d18f29e946468e89bfce9a980c0"
-  integrity sha512-6DNDY3LC/GuoQPO5nu2poLxhQwaNlEv/r+dwoK7AZsLdJ86hU30l5wZbZLFErNYf2sv82rSoeaWxr1w7bRxMGw==
+"@joystream/types@^0.18.1":
+  version "0.18.2"
+  resolved "https://registry.yarnpkg.com/@joystream/types/-/types-0.18.2.tgz#fd82d28cb14145784d3b3e18857fa8df76c97a01"
+  integrity sha512-ylvC0g3BjirWhbrlgkWLnCzcIntzlFwnObNyYCQ7pV4//TrwGPeS6ozdKnFNlzUz/xRfY3GMCedl5Sa6Def5BQ==
   dependencies:
     "@polkadot/api" "5.9.1"
     "@polkadot/keyring" "7.3.1"


### PR DESCRIPTION
Changes:
- Set `@joystream/types` package version to `^0.18.1`
- Update `councilData` function to work with the new types (used [this code](https://github.com/Joystream/pioneer/blob/olympia/packages%2Fui%2Fsrc%2Fcouncil%2Fhooks%2FuseElectionStage.ts) as inspiration)
- Removed memo from `transfers.ts` and from the `Exchange` type in `db.ts`