### PR TITLE
Add total supply endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ out.log
 exchanges.json
 carousel-data.json
 circulating-supply-data.json
+total-supply-data.json

--- a/src/app.ts
+++ b/src/app.ts
@@ -42,7 +42,7 @@ const scheduleCronJob = async () => {
 
   // Fetch data initially such that we have something to serve. There will at most
   // be a buffer of 5 minutes from this running until the first cron execution.
-  if (!(fs.existsSync(CIRCULATING_SUPPLY_DATA_PATH) && fs.existsSync(TOTAL_SUPPLY_DATA_PATH)))
+  if (!fs.existsSync(CIRCULATING_SUPPLY_DATA_PATH) || !fs.existsSync(TOTAL_SUPPLY_DATA_PATH))
     await fetchAndWriteSupplyData();
   if (!fs.existsSync(CAROUSEL_DATA_PATH)) await fetchAndWriteCarouselData();
 

--- a/src/get-circulating-supply.ts
+++ b/src/get-circulating-supply.ts
@@ -1,6 +1,3 @@
-// Thoughts on what I need to do:
-// So, idea is to find out the transferrable balance for every on-chain account and add it up.
-
 import { JoyApi } from "./joyApi";
 
 const api = new JoyApi();

--- a/src/get-total-supply.ts
+++ b/src/get-total-supply.ts
@@ -1,0 +1,13 @@
+import { JoyApi } from "./joyApi";
+
+const api = new JoyApi();
+
+const getTotalSupply = async () => {
+  await api.init;
+
+  const totalSupply = await api.totalIssuanceInJOY();
+
+  return { totalSupply };
+};
+
+export default getTotalSupply;


### PR DESCRIPTION
This PR aims to implement the total supply endpoint on the status server.

Notes:
- There was the option of using the `apicache` npm package and the implementation would have been much simpler but I decided to go with the current (cron) approach to make sure the two values don't go out of sync with one another. There's also the fact that the initial fetch would always be fairly slow.
- I also thought about returning `totalSupply` from `api.calculateCirculatingSupply` as we already fetch that there as a way to optimize the fetching process but thought it'd sacrifice the modularity/readability(?) so decided against it. I'll defer judgment here and I am fine with either way.